### PR TITLE
use vim.notify for notification messages

### DIFF
--- a/lua/toggle_lsp_diagnostics.lua
+++ b/lua/toggle_lsp_diagnostics.lua
@@ -83,7 +83,7 @@ function M.toggle_diagnostics()
   else
     M.turn_on_diagnostics()
   end
-  M.display_status('all diagnostics are', M.settings.all)
+  M.display_status('All diagnostics are', M.settings.all)
 end
 
 function M.toggle_diagnostic(name)
@@ -140,9 +140,9 @@ end
 
 function M.display_status(msg, val)
   if val == false then
-    vim.api.nvim_echo({ { string.format('%s off', msg) } }, false, {})
+    vim.notify(string.format('%s off', msg), vim.log.levels.INFO)
   else
-    vim.api.nvim_echo({ { string.format('%s on', msg) } }, false, {})
+    vim.notify(string.format('%s on', msg), vim.log.levels.INFO)
   end
 end
 


### PR DESCRIPTION
This PR uses vims builtin `vim.notify` instead of just echoing. This allows notification messages to be hooked by notification providers instead of limiting them to the cmd line.

If no notification plugin is installed the behavior won't change:

![without](https://user-images.githubusercontent.com/34311583/216797371-da32a8fc-ae76-4394-936f-cda271a1638c.png)

Example with the nvim-notify plugin:

![notify](https://user-images.githubusercontent.com/34311583/216797385-ddaea2f5-5272-4d3d-838b-66a567931ff7.png)

Example with notifier.nvim:

![notifier](https://user-images.githubusercontent.com/34311583/216797550-733032a4-b635-490c-bd51-eefede15a9fe.png)

As a second thing (not visible on the screenshots) I also took the liberty to capitalize the first word of the info message. As sentence-case is the common convention for notifications and it looks a tiny bit nicer. 